### PR TITLE
Add simpleCors

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -29,6 +29,7 @@ import           Lucid
 import           Network.HTTP.Media            ((//), (/:))
 import           Network.Wai
 import           Network.Wai.Handler.Warp
+import           Network.Wai.Middleware.Cors   (simpleCors)
 import           Servant
 import           Servant.Types.SourceT         (source)
 import           System.Directory
@@ -66,7 +67,7 @@ app :: Application
 app = serve simAPI server
 
 main :: IO ()
-main = run 8080 app
+main = run 8080 $ simpleCors app
 
 someSteps :: [Step]
 someSteps = boringStep <$> [1..50]

--- a/sirsimulation.cabal
+++ b/sirsimulation.cabal
@@ -28,6 +28,7 @@ common deps
                      , text
                      , time
                      , wai
+                     , wai-cors
                      , warp
 
 library


### PR DESCRIPTION
Without `simpleCors` middleware, I was occasionally getting CORS errors. Not consistently, so its something of a mystery. However adding `simpleCors` seems to fix it.

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/26548438/76692189-61e03f80-6629-11ea-88e5-f19308c37273.png">
